### PR TITLE
Fix loader syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ module.exports = {
     rules: [{
       enforce: 'pre',
       test: /\.html/,
-      loader: 'htmlhint',
+      loader: 'htmlhint-loader',
       exclude: /node_modules/
     }]
   }
@@ -41,7 +41,7 @@ module.exports = {
     rules: [{
       enforce: 'pre',
       test: /\.html/,
-      loader: 'htmlhint?{tagname-lowercase: true}',
+      loader: 'htmlhint-loader?{tagname-lowercase: true}',
       exclude: /node_modules/
     }]
   }
@@ -56,7 +56,7 @@ module.exports = {
     rules: [{
       enforce: 'pre',
       test: /\.html/,
-      loader: 'htmlhint',
+      loader: 'htmlhint-loader',
       exclude: /node_modules/,
       options: {
         configFile: 'path/.htmlhintrc'
@@ -104,7 +104,7 @@ module.exports = {
     rules: [{
       enforce: 'pre',
       test: /\.html/,
-      loader: 'htmlhint',
+      loader: 'htmlhint-loader',
       exclude: /node_modules/,
       options: {
         customRules: [{
@@ -133,7 +133,7 @@ module.exports = {
     rules: [{
       enforce: 'pre',
       test: /\.html/,
-      loader: 'htmlhint',
+      loader: 'htmlhint-loader',
       exclude: /node_modules/,
       options: {
         outputReport: {


### PR DESCRIPTION
(Howdy again from the states!)

An issue I ran into while migrating my projects to Webpack 2 is that it does not auto-append `-loader` to the loader's name as Webpack 1 did. This means that Webpack will try to load `htmlhint` itself from node_modules as the loader instead of `htmlhint-loader`, giving off an error message like:
```
Error: Module '/home/lite/code/Webtrader/node_modules/htmlhint/index.js' is not a loader (must have normal or pitch function)
```

I tested that the syntax `loader: 'htmlhint-loader'` works just the same on Webpack 1.6 as it does Webpack 2.4, so I think the readme example should reflect that. Let me know if I am missing something, and thanks for one of your many great tools! 