### PR TITLE
Removing `this.options.htmlhint || {}` from `options`

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,7 +140,6 @@ module.exports = function (source) {
       customRules: [],
       configFile: DEFAULT_CONFIG_FILE
     },
-    this.options.htmlhint || {}, // User defaults
     loaderUtils.getOptions(this) // Loader query string
   );
 


### PR DESCRIPTION
Attempting to extend defaults with `this.options.htmlhint` before `this.options` is defined.

Removing this line as I didn't see any other references to it in the script.

This will fix #13.

@mattlewis92 Please let me know if I'm missing the intent of this and I can update the PR to reflect.

Thanks!